### PR TITLE
Prerelease cleanup

### DIFF
--- a/src/bind-all.ts
+++ b/src/bind-all.ts
@@ -48,6 +48,7 @@ export function bindAll<
       // we use `TTypes[K] & string` instead to workaround this issue and it works fine
       // but using `Binding<TTarget, TTypes[K] & string>` is not an option
       // as we need to keep `TTypes[K]` "naked" at the `type` property, for it to be a valid inference candidate
+      // without that we'd lose the autocompletes for the `type` property
       [K in keyof TTypes]: {
         type: TTypes[K];
         listener: Listener<TTarget, TTypes[K] & string>;

--- a/src/bind-all.ts
+++ b/src/bind-all.ts
@@ -1,4 +1,4 @@
-import { Binding, InferEventType, Listener, UnbindFn } from './types';
+import { Binding, InferEventType, UnbindFn } from './types';
 import { bind } from './bind';
 
 function toOptions(value?: boolean | AddEventListenerOptions): AddEventListenerOptions | undefined {
@@ -42,11 +42,7 @@ export function bindAll<
   target: TTarget,
   bindings: [
     ...{
-      [K in keyof TTypes]: {
-        type: TTypes[K];
-        listener: Listener<TTarget, TTypes[K] & string>;
-        options?: boolean | AddEventListenerOptions;
-      };
+      [K in keyof TTypes]: Binding<TTarget, TTypes[K]>;
     }
   ],
   sharedOptions?: boolean | AddEventListenerOptions,

--- a/src/bind-all.ts
+++ b/src/bind-all.ts
@@ -1,4 +1,4 @@
-import { Binding, InferEvent, InferEventType, Listener, UnbindFn } from './types';
+import { Binding, InferEventType, Listener, UnbindFn } from './types';
 import { bind } from './bind';
 
 function toOptions(value?: boolean | AddEventListenerOptions): AddEventListenerOptions | undefined {
@@ -44,14 +44,7 @@ export function bindAll<
     ...{
       [K in keyof TTypes]: {
         type: TTypes[K];
-        listener: Listener<
-          TTarget,
-          InferEvent<
-            TTarget,
-            // `& string` "cast" is not needed since TS 4.7 (but the repo is using TS 4.6 atm)
-            TTypes[K] & string
-          >
-        >;
+        listener: Listener<TTarget, TTypes[K] & string>;
         options?: boolean | AddEventListenerOptions;
       };
     }

--- a/src/bind.ts
+++ b/src/bind.ts
@@ -1,23 +1,9 @@
-import { UnbindFn, InferEventType, Listener } from './types';
+import { UnbindFn, InferEventType, Binding } from './types';
 
 export function bind<
   TTarget extends EventTarget,
   TType extends InferEventType<TTarget> | (string & {}),
->(
-  target: TTarget,
-  // this "inline" variant works better when it comes to limiting `InferEvent` to using the `TType` from the "outer scope" (bind's and not Binding's)
-  // we can still export Binding and it could be used by people if they with to. To aid inference we can keep this inline within `bind`'s signature
-  // most likely we'll be able to refactor this when https://github.com/microsoft/TypeScript/pull/51770 gets released in TS 5.0
-  {
-    type,
-    listener,
-    options,
-  }: {
-    type: TType;
-    listener: Listener<TTarget, TType>;
-    options?: boolean | AddEventListenerOptions;
-  },
-): UnbindFn {
+>(target: TTarget, { type, listener, options }: Binding<TTarget, TType>): UnbindFn {
   target.addEventListener(type, listener, options);
 
   return function unbind() {

--- a/src/bind.ts
+++ b/src/bind.ts
@@ -5,14 +5,6 @@ export function bind<
   TType extends InferEventType<TTarget> | (string & {}),
 >(
   target: TTarget,
-  // binding: Binding<
-  //   TTarget,
-  //   // `| (string & {})` should be moved to the Type's constraint
-  //   // however, doing that today breaks autocompletion
-  //   // this is being by https://github.com/microsoft/TypeScript/pull/51770 but we need wait for its release in TS 5.0
-  //   TType | (string & {})
-  // >
-
   // this "inline" variant works better when it comes to limiting `InferEvent` to using the `TType` from the "outer scope" (bind's and not Binding's)
   // we can still export Binding and it could be used by people if they with to. To aid inference we can keep this inline within `bind`'s signature
   // most likely we'll be able to refactor this when https://github.com/microsoft/TypeScript/pull/51770 gets released in TS 5.0

--- a/src/bind.ts
+++ b/src/bind.ts
@@ -1,4 +1,4 @@
-import { UnbindFn, InferEventType, InferEvent, Listener } from './types';
+import { UnbindFn, InferEventType, Listener } from './types';
 
 export function bind<
   TTarget extends EventTarget,
@@ -14,7 +14,7 @@ export function bind<
     options,
   }: {
     type: TType;
-    listener: Listener<TTarget, InferEvent<TTarget, TType>>;
+    listener: Listener<TTarget, TType>;
     options?: boolean | AddEventListenerOptions;
   },
 ): UnbindFn {

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,7 +14,7 @@ export type InferEventType<TTarget> = TTarget extends {
   ? P & string
   : never;
 
-export type InferEvent<TTarget, TType extends string> = `on${TType}` extends keyof TTarget
+type InferEvent<TTarget, TType extends string> = `on${TType}` extends keyof TTarget
   ? Parameters<Extract<TTarget[`on${TType}`], UnknownFunction>>[0]
   : Event;
 
@@ -24,12 +24,12 @@ type ListenerObject<TEvent extends Event> = {
 };
 
 // event listeners can be an object or a function
-export type Listener<TTarget extends EventTarget, TEvent extends Event> =
-  | ListenerObject<TEvent>
-  | { (this: TTarget, ev: TEvent): void };
+export type Listener<TTarget extends EventTarget, TType extends string> =
+  | ListenerObject<InferEvent<TTarget, TType>>
+  | { (this: TTarget, ev: InferEvent<TTarget, TType>): void };
 
 export type Binding<TTarget extends EventTarget = EventTarget, TType extends string = string> = {
   type: TType;
-  listener: Listener<TTarget, InferEvent<TTarget, TType>>;
+  listener: Listener<TTarget, TType>;
   options?: boolean | AddEventListenerOptions;
 };


### PR DESCRIPTION
Cleaning up after the refactoring done in https://github.com/alexreardon/bind-event-listener/pull/44

The main goal here was to revert some of the changes related to the "shape" of generics, to replace `TEvent extends Event` with `TType extends string`.

I believe that this version now should have a wide support range of TS versions. However, the autocompletes only work in TS 5.0 (which is fine, progressive enhancement and all). Please retest this if you can though.