### PR TITLE
Reexport InferEventType in index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export { bind } from './bind';
 export { bindAll } from './bind-all';
-export { Binding, Listener, UnbindFn } from './types';
+export { Binding, Listener, UnbindFn, InferEventType } from './types';


### PR DESCRIPTION
When using `bind` in helper functions/libraries/etc it's necessary to use the `InferEventType` to get correct event types for the target.
For instance, I want to create a React hook to add global event listeners to `window`, `document` etc:

```tsx
function SomeReactComponent() {
  useGlobalEventListener(window, "focus", (event) => {
    console.log("Event:", event);
  }, []);

  // …
};

function useGlobalEventListener<
  TTarget extends EventTarget,
  TType extends InferEventType<TTarget>,
>(
  target: TTarget,
  type: TType,
  listener: Listener<TTarget, TType>,
  deps: DependencyList
) {
  useEffect(() => {
    if (!target) {
      return;
    }

    const unbind = bind(target, { type, listener });

    return () => {
      unbind();
    };
  }, [target, type, ...deps]);
}
```

However, since `InferEventType` isn't reexported from `index.ts` you have to do a bit of a hackish import from src/types.ts instead:

```ts
import type { InferEventType, Listener } from "bind-event-listener/src/types";
```

This doesn't give me any file path completion in vscode, so you need to know the exact source of the file with the typings.
I think it makes sense to reexport `InferEventType` from `index.ts` for these kinds of use cases.